### PR TITLE
いいねした記事が削除された状態でマイページを開くとエラーになる問題を修正。記事が削除されると、それに紐づくいいね！とコメントも削除されるよ…

### DIFF
--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -41,4 +41,14 @@ class Article extends Model
     public function isLikedBy($user): bool {
         return Like::where('user_id', $user->id)->where('article_id', $this->id)->first() !==null;
     }
+
+    public static function boot()
+    {
+        parent::boot();
+
+        static::deleting(function ($article) {
+            $article->likes()->delete();
+            $article->comments()->delete();
+        });
+    }
 }


### PR DESCRIPTION
…うに変更。